### PR TITLE
Persists network settings (host and port)

### DIFF
--- a/remote-wiring-experience/ConnectionPage.xaml.cs
+++ b/remote-wiring-experience/ConnectionPage.xaml.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Windows.UI.Xaml.Media.Imaging;
 using Windows.UI.Xaml.Media;
+using Windows.Storage;
 
 // The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=402352&clcid=0x409
 
@@ -33,6 +34,9 @@ namespace remote_wiring_experience
         Image wire;
 
         bool navigated = false;
+
+        const string SETTINGS_HOST = "networkHost";
+        const string SETTINGS_PORT = "networkPort";
 
         public ConnectionPage()
         {
@@ -117,6 +121,21 @@ namespace remote_wiring_experience
                     NetworkPortTextBox.IsEnabled = true;
                     BaudRateComboBox.IsEnabled = false;
                     ConnectMessage.Text = "Enter a host and port to connect.";
+
+                    // Last working host and port is persisted across sessions. Retrieve this data.
+                    var host = ApplicationData.Current.LocalSettings.Values[SETTINGS_HOST];
+                    var port = ApplicationData.Current.LocalSettings.Values[SETTINGS_PORT];
+                    if (host != null && port != null)
+                    {
+                        NetworkHostNameTextBox.Text = host.ToString();
+                        NetworkPortTextBox.Text = port.ToString();
+                    }
+                    else
+                    {
+                        NetworkHostNameTextBox.Text = "";
+                        NetworkPortTextBox.Text = "";
+                    }
+
                     task = null;
                     break;
             }
@@ -306,6 +325,10 @@ namespace remote_wiring_experience
             {
                 timeout.Stop();
                 ConnectMessage.Text = "Successfully connected!";
+
+                // Store the host and port settings
+                ApplicationData.Current.LocalSettings.Values[SETTINGS_HOST] = NetworkHostNameTextBox.Text;
+                ApplicationData.Current.LocalSettings.Values[SETTINGS_PORT] = NetworkPortTextBox.Text;
 
                 //telemetry
                 connectionStopwatch.Stop();


### PR DESCRIPTION
Uses `LocalSettings` to persist the host name and port number for the last successful connection.
I did it because this data rarely changes and is cumbersome to enter each time.
![img](https://i.gyazo.com/4b9de60499478e9d23b86c550396c90f.png)
